### PR TITLE
Updated rewire to use new import style

### DIFF
--- a/src/test-natural.ts
+++ b/src/test-natural.ts
@@ -1,5 +1,5 @@
 import { Type, Value } from "sinap-types";
-import * as rewire from "rewire";
+import rewire = require("rewire");
 
 const natural = rewire("./natural");
 const fromValueInner = natural.__get__('fromValueInner');


### PR DESCRIPTION
The project currently doesn't build because of this. We should really probably fix some of these dependencies with a ~ instead of ^ so that stuff doesn't break as much.