### PR TITLE
Import modules from node_modules for plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sinap-typescript-loader",
   "description": "Bindings for synap-types from typescript",
-  "version": "0.4.22",
+  "version": "0.5.22",
   "readme": "README.md",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,18 +23,20 @@
     "clean": "rimraf ./node_modules ./typings ./lib"
   },
   "devDependencies": {
-    "@types/node": "^7.0.12",
-    "chai": "^3.5.0",
     "@types/chai": "^3.4.35",
-    "mocha": "^3.2.0",
     "@types/mocha": "^2.2.40",
-    "rimraf": "^2.6.1",
-    "rewire": "^2.5.2",
+    "@types/node": "^7.0.12",
+    "@types/resolve": "0.0.4",
     "@types/rewire": "^2.5.27",
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0",
+    "rewire": "^2.5.2",
+    "rimraf": "^2.6.1",
     "tslint": "^4.5.1",
     "typescript-formatter": "^5.1.2"
   },
   "dependencies": {
+    "resolve": "~1.4.0",
     "sinap-core": "~3.11.4",
     "sinap-types": "0.6.3",
     "typescript": "https://github.com/Sheyne/TypeScript/releases/download/sheyne-2.3.0-beta2/typescript-2.3.0.tgz"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sinap-typescript-loader",
   "description": "Bindings for synap-types from typescript",
-  "version": "0.5.22",
+  "version": "0.5.0",
   "readme": "README.md",
   "license": "MIT",
   "repository": {

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 import { Plugin, PluginLoader, PluginInfo } from "sinap-core";
 import { TypescriptPlugin } from "./plugin";
+// import resolve = require("resolve");
 import * as fs from "fs";
 import * as path from "path";
 
@@ -67,7 +68,7 @@ export class TypescriptPluginLoader implements PluginLoader {
         return readFile(pluginLocation).then((pluginScript) => {
             const host = createCompilerHost(new Map([
                 ["plugin.ts", pluginScript]
-            ]), options, emitter, this.appDirectory);
+            ]), pluginInfo.interpreterInfo.directory, options, emitter, this.appDirectory);
 
             const program = ts.createProgram(["plugin.ts"], options, host);
             // TODO: only compute if asked for.
@@ -86,16 +87,18 @@ export class TypescriptPluginLoader implements PluginLoader {
     }
 }
 
-function createCompilerHost(files: Map<string, string>, options: ts.CompilerOptions, emit: (name: string, content: string) => void, appDirectory?: string): ts.CompilerHost {
+function createCompilerHost(files: Map<string, string>, pluginDir: string, options: ts.CompilerOptions, emit: (name: string, content: string) => void, appDirectory?: string): ts.CompilerHost {
     return {
         getSourceFile: (fileName): ts.SourceFile => {
             let source = files.get(fileName);
             if (!source) {
                 // if we didn't bundle the source file, maybe it's a lib?
                 if (fileName.indexOf("/") !== -1) {
-                    throw Error("no relative/absolute paths here");
+                    // Should probably put a security check here.
+                    source = fs.readFileSync(fileName, "utf8");
+                } else {
+                    source = fs.readFileSync(path.join(appDirectory ? appDirectory : ".", "node_modules", "typescript", "lib", fileName), "utf8");
                 }
-                source = fs.readFileSync(path.join(appDirectory ? appDirectory : ".", "node_modules", "typescript", "lib", fileName), "utf8");
             }
 
             // any to suppress strict error about undefined
@@ -109,15 +112,13 @@ function createCompilerHost(files: Map<string, string>, options: ts.CompilerOpti
         getDefaultLibFileName: () => {
             return "lib.es2016.d.ts";
         },
-        useCaseSensitiveFileNames: () => false,
+        useCaseSensitiveFileNames: () => true,
         getCanonicalFileName: fileName => fileName,
-        getCurrentDirectory: () => "",
+        getCurrentDirectory: () => pluginDir,
         getNewLine: () => "\n",
-        fileExists: (fileName): boolean => {
-            return files.has(fileName);
-        },
-        readFile: () => "",
-        directoryExists: () => true,
-        getDirectories: () => []
+        fileExists: ts.sys.fileExists,
+        readFile: ts.sys.readFile,
+        directoryExists: ts.sys.directoryExists,
+        getDirectories: ts.sys.readDirectory
     };
 }

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -1,7 +1,6 @@
 import * as ts from "typescript";
 import { Plugin, PluginLoader, PluginInfo } from "sinap-core";
 import { TypescriptPlugin } from "./plugin";
-// import resolve = require("resolve");
 import * as fs from "fs";
 import * as path from "path";
 

--- a/src/test-natural.ts
+++ b/src/test-natural.ts
@@ -1,5 +1,5 @@
 import { Type, Value } from "sinap-types";
-import * as rewire from "rewire";
+import rewire = require("rewire");
 
 const natural = rewire("./natural");
 const fromValueInner = natural.__get__('fromValueInner');

--- a/test-support/subpackage/interpreter.ts
+++ b/test-support/subpackage/interpreter.ts
@@ -1,0 +1,25 @@
+import * as _ from "lodash";
+
+export class Node {
+}
+
+export class Edge {
+}
+
+export class Graph {
+    nodes: Nodes[];
+}
+
+export type Nodes = Node;
+export type Edges = Edge;
+
+export class State {
+}
+
+export function start(graph: Graph, input: number): State | number {
+    return _.add(input, 1);
+}
+
+export function step(graph: Graph, input: number): State | number {
+    return 0;
+}

--- a/test-support/subpackage/package.json
+++ b/test-support/subpackage/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "subpackage",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "sinap": {
+    "kind": [
+      "test",
+      "subpackage"
+    ],
+    "plugin-file": "interpreter.ts",
+    "description": "A plugin which uses its own node_modules.",
+    "loader": "typescript"
+  },
+  "dependencies": {
+    "lodash": "~4.17.4"
+  },
+  "devDependencies": {
+    "@types/lodash": "~4.14.74"
+  }
+}


### PR DESCRIPTION
This depends on #13 to be merged first.

This update allows plugins to use code they import from node_modules allowing for them to utilize convenient utilities such as lodash.